### PR TITLE
Add babel-cli devDependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "react": "^0.13.3"
   },
   "devDependencies": {
-    "babel-core": "^5.8.3",
-    "babel-loader": "^5.3.2",
+    "babel-cli": "^6.2.0",
+    "babel-core": "^6.2.1",
+    "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.1.2",
     "babel-preset-react": "^6.1.2",
     "css-loader": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "clean": "rimraf dist lib",
     "build": "npm run build:lib && npm run build:dev && npm run build:prod",
-    "build:lib": "babel src --out-dir lib --presets es2015,react",
+    "build:lib": "babel src --out-dir lib",
     "build:dev": "webpack lib/main.js dist/react-pinterest.js --config webpack.config.base.js",
     "build:prod": "webpack lib/main.js dist/react-pinterest.min.js --config webpack.config.prod.js",
     "postinstall": "npm run build",


### PR DESCRIPTION
This fixes `npm run build` from failing if the user doesn't have `babel-cli` installed globally (and also ensures that `react-pinterest` is built with the specified version instead of whatever is installed globally).

Also updates `babel-core` and `babel-loader`.
