### PR TITLE
Made React a `peerDependency` and `devDependency` instead of `dependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "directories": {
     "example": "examples"
   },
-  "dependencies": {
-    "react": "^0.13.3"
-  },
   "devDependencies": {
     "babel-core": "^5.8.3",
     "babel-loader": "^5.3.2",
@@ -17,11 +14,15 @@
     "babel-preset-react": "^6.1.2",
     "css-loader": "~0.9.0",
     "express": "^4.13.3",
+    "react": "^0.13.3",
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.4.4",
     "style-loader": "~0.8.0",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.12.1"
+  },
+  "peerDependencies": {
+    "react": "^0.13.3"
   },
   "scripts": {
     "clean": "rimraf dist lib",


### PR DESCRIPTION
This is to avoid two versions of [React being packaged among other things](http://stackoverflow.com/a/30454133/135913).

It's [less of a problem with React 0.14](https://github.com/facebook/react/pull/3332#issuecomment-130128100) but since this module works for React 0.13 as well it shouldn't really have React as a normal `dependency`.
