### PR TITLE
Remove window/document dependencies on initial load

### DIFF
--- a/src/components/PinItButton.js
+++ b/src/components/PinItButton.js
@@ -2,6 +2,8 @@ import React from 'react';
 
 import PinterestBase from './PinterestBase';
 import Anchor from './PinterestAnchor';
+
+import Config from '../util/PinConfig';
 import Const from '../util/PinConst';
 import Util from '../util/PinUtil';
 
@@ -38,7 +40,7 @@ export default class PinItButton extends PinterestBase {
         const shape = round ? 'round' : 'rect';
         const size = round ? (large ? '32' : '16') : (large ? '28' : '20');
         const _color = round ? 'red' : color;
-        const resolution = this.config.resolution;
+        const resolution = Util.getResolution();
         return `//s-passets.pinimg.com/images/pidgets/pinit_bg_en_${shape}_${_color}_${size}_${resolution}.png`;
     }
 
@@ -81,12 +83,12 @@ export default class PinItButton extends PinterestBase {
         const {pin, media, url, description} = this.props;
         let href;
         if (pin) {
-            href = Const.URL.REPIN.replace('<id>', pin) + `?guid=${this.config.guid}`;
+            href = Const.URL.REPIN.replace('<id>', pin) + `?guid=${Config.guid}`;
         } else {
-            href = Const.URL.PIN_CREATE + `?guid=${this.config.guid}`;
+            href = Const.URL.PIN_CREATE + `?guid=${Config.guid}`;
             href += `&media=${encodeURIComponent(media)}`;
-            href += `&url=${encodeURIComponent(url)}`;
-            href += `&description=${encodeURIComponent(description)}`;
+            href += `&url=${encodeURIComponent(url || document.URL)}`;
+            href += `&description=${encodeURIComponent(description || document.title)}`;
         }
         return (
             <Anchor className={this.getClasses()} href={href} log="button_pinit" popup="pin_create" >
@@ -145,6 +147,6 @@ PinItButton.defaultProps = {
     round: false,
     pin: null,
     media: null,
-    url: document.URL,
-    description: document.title
+    url: '',
+    description: ''
 };

--- a/src/components/PinterestBase.js
+++ b/src/components/PinterestBase.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Config from '../util/PinConfig';
 import Const from '../util/PinConst';
 import i18n from '../util/i18n';
 import Util from '../util/PinUtil';
@@ -12,55 +13,26 @@ export default class PinterestBase extends React.Component {
 
     constructor(props) {
         super(props)
-        this.ensureConfig();
         this.debounceInitialLogging();
         i18n.setLang(this.props.lang || 'en');
-    }
-
-    /**
-     * Only set config data once. This will create the tracking guid and
-     * initialize the widget counts.
-     */
-    ensureConfig() {
-        if (!window[Const.GLOBAL]) {
-            var config = {
-                guid: '',
-                initialized: false,
-                resolution: window.devicePixelRatio >= 2 ? 2 : 1,
-                callbacks: [],
-                [Const.COUNT.BUTTON]: 0,
-                [Const.COUNT.FOLLOW]: 0,
-                [Const.COUNT.PIN_SMALL]: 0,
-                [Const.COUNT.PIN_MEDIUM]: 0,
-                [Const.COUNT.PIN_LARGE]: 0,
-                [Const.COUNT.PROFILE]: 0,
-                [Const.COUNT.BOARD]: 0
-            };
-            for (var i = 0; i < 12; i++) {
-                config.guid += Const.GUID_VARS.substr(Math.floor(Math.random() * 60), 1);
-            }
-            window[Const.GLOBAL] = config;
-        }
-        this.config = window[Const.GLOBAL];
     }
 
     /**
      * Wait for the page to settle before logging the widget counts
      */
     debounceInitialLogging() {
-        if (!window[Const.GLOBAL].initialized) {
+        if (!Config.initialized) {
             clearTimeout(this.timeout);
             this.timeout = setTimeout(() => {
-                var data = window[Const.GLOBAL];
-                data.initialized = true;
+                Config.initialized = true;
                 Util.log({
-                    [Const.COUNT.BUTTON]: data[Const.COUNT.BUTTON],
-                    [Const.COUNT.FOLLOW]: data[Const.COUNT.FOLLOW],
-                    [Const.COUNT.PIN_SMALL]: data[Const.COUNT.PIN_SMALL],
-                    [Const.COUNT.PIN_MEDIUM]: data[Const.COUNT.PIN_MEDIUM],
-                    [Const.COUNT.PIN_LARGE]: data[Const.COUNT.PIN_LARGE],
-                    [Const.COUNT.PROFILE]: data[Const.COUNT.PROFILE],
-                    [Const.COUNT.BOARD]: data[Const.COUNT.BOARD]
+                    [Const.COUNT.BUTTON]: Config[Const.COUNT.BUTTON],
+                    [Const.COUNT.FOLLOW]: Config[Const.COUNT.FOLLOW],
+                    [Const.COUNT.PIN_SMALL]: Config[Const.COUNT.PIN_SMALL],
+                    [Const.COUNT.PIN_MEDIUM]: Config[Const.COUNT.PIN_MEDIUM],
+                    [Const.COUNT.PIN_LARGE]: Config[Const.COUNT.PIN_LARGE],
+                    [Const.COUNT.PROFILE]: Config[Const.COUNT.PROFILE],
+                    [Const.COUNT.BOARD]: Config[Const.COUNT.BOARD]
                 });
             }, 1000);
         }
@@ -72,6 +44,6 @@ export default class PinterestBase extends React.Component {
      * @param {string} type - the type of widget to log
      */
     logCount(type) {
-        this.config[type]++;
+        Config[type]++;
     }
 }

--- a/src/components/PinterestFollowButton.js
+++ b/src/components/PinterestFollowButton.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import PinterestBase from './PinterestBase';
 import Anchor from './PinterestAnchor';
+import Config from '../util/PinConfig';
 import Const from '../util/PinConst';
 import Util from '../util/PinUtil';
 
@@ -30,9 +31,9 @@ export default class PinterestFollowButton extends PinterestBase {
     render() {
         let href;
         if (this.props.board) {
-            href = `https://www.pinterest.com/${this.props.board}/follow/?guid=${this.config.guid}`;
+            href = `https://www.pinterest.com/${this.props.board}/follow/?guid=${Config.guid}`;
         } else {
-            href = `https://www.pinterest.com/${this.props.user}/pins/follow/?guid=${this.config.guid}`
+            href = `https://www.pinterest.com/${this.props.user}/pins/follow/?guid=${Config.guid}`
         }
         return (
             <Anchor className="pinterest-follow-button" href={href} log="button_follow" popup="follow">

--- a/src/components/PinterestPinWidget.js
+++ b/src/components/PinterestPinWidget.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import PinterestBase from './PinterestBase';
 import Anchor from './PinterestAnchor';
+import Config from '../util/PinConfig';
 import Const from '../util/PinConst';
 import i18n from '../util/i18n';
 import Util from '../util/PinUtil';
@@ -63,7 +64,7 @@ export default class PinterestPinWidget extends PinterestBase {
      */
     handlePinit(evt) {
         evt.preventDefault();
-        const href = `https://www.pinterest.com/pin/${this.state.pin.id}/repin/x/?guid=${this.config.guid}`;
+        const href = `https://www.pinterest.com/pin/${this.state.pin.id}/repin/x/?guid=${Config.guid}`;
         window.open(href, 'pin' + new Date().getTime(), Const.POPUP_OPTIONS.PIN_CREATE);
         Util.log({ type: 'embed_pin_repin' + this.logSize, href: href });
     }
@@ -90,7 +91,7 @@ export default class PinterestPinWidget extends PinterestBase {
      */
     getButtonImage() {
         const base = 'https://s-passets.pinimg.com/images/pidgets/';
-        const resolution = this.config.resolution;
+        const resolution = Util.getResolution();
         let url;
         if (this.props.lang === 'ja') {
             url = `pinit_bg_ja_rect_red_20_${resolution}.png`;
@@ -139,7 +140,7 @@ export default class PinterestPinWidget extends PinterestBase {
      * for ability to report copyright infringement
      */
     renderMenu() {
-        const resolution = this.config.resolution;
+        const resolution = Util.getResolution();
         const image = `url(https://s-passets.pinimg.com/images/pidgets/menu_${resolution}.png)`;
         return (
             <span>

--- a/src/util/PinConfig.js
+++ b/src/util/PinConfig.js
@@ -1,0 +1,17 @@
+import Const from './PinConst';
+
+let guid = '';
+for (var i = 0; i < 12; i++) {
+    guid += Const.GUID_VARS.substr(Math.floor(Math.random() * 60), 1);
+}
+
+export default {
+    guid: guid,
+    [Const.COUNT.BUTTON]: 0,
+    [Const.COUNT.FOLLOW]: 0,
+    [Const.COUNT.PIN_SMALL]: 0,
+    [Const.COUNT.PIN_MEDIUM]: 0,
+    [Const.COUNT.PIN_LARGE]: 0,
+    [Const.COUNT.PROFILE]: 0,
+    [Const.COUNT.BOARD]: 0
+};

--- a/src/util/PinUtil.js
+++ b/src/util/PinUtil.js
@@ -1,3 +1,4 @@
+import Config from './PinConfig';
 import Const from './PinConst';
 
 /**
@@ -9,8 +10,7 @@ export default {
      * @param {object} data - key/value pairs of query parameters to log
      */
     log: function(data) {
-        const config = window[Const.GLOBAL];
-        let query = `?guid=${config.guid}&via=${encodeURIComponent(location.href)}`;
+        let query = `?guid=${Config.guid}&via=${encodeURIComponent(location.href)}`;
         Object.keys(data).forEach(key => query += `&${key}=${encodeURIComponent(data[key])}`);
         this.loadScript(Const.URL.LOG + query, {});
     },
@@ -36,16 +36,14 @@ export default {
      * @param {function} callback - the callback to be called on complete
      */
     fetch: function(url, callback) {
-        const config = window[Const.GLOBAL];
-        const length = config.callbacks.length;
-        const key = `window.${Const.GLOBAL}.callbacks[${length}]`;
-        const src = `${url}&callback=${key}`;
-        config.callbacks.push(callback);
-        this.loadScript(src, {
-            id: key,
-            type: 'text/javascript',
-            charset: 'utf-8'
-        });
+        var request = new XMLHttpRequest();
+        request.open('GET', url, true);
+        request.onload = function() {
+          if (request.status >= 200 && request.status < 400) {
+            callback(JSON.parse(request.responseText));
+          }
+        };
+        request.send();
     },
 
     /**
@@ -63,6 +61,18 @@ export default {
             }
         });
         return base;
+    },
+
+    /**
+     * Allow for server rendering
+     * @returns {number} the screen resolution
+     */
+    getResolution: function() {
+        if (window) {
+            return window.devicePixelRatio >= 2 ? 2 : 1;
+        } else {
+            return 1;
+        }
     },
 
     /**


### PR DESCRIPTION
This PR is to allow server side rendering, by removing window/document dependencies outside of user interaction callbacks. As part of it, we switched from using jsonp callbacks to using XMLHttpRequests which are now supported for the widget endpoints.

@growlsworth
