### PR TITLE
Remove `postinstall` directive to fix npm installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,13 @@
     "build:lib": "babel src --out-dir lib",
     "build:dev": "webpack lib/main.js dist/react-pinterest.js --config webpack.config.base.js",
     "build:prod": "webpack lib/main.js dist/react-pinterest.min.js --config webpack.config.prod.js",
-    "postinstall": "npm run build",
     "prepublish": "npm run clean && npm run build"
   },
+  "files": [
+    "dist/",
+    "lib/",
+    "src/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/pinterest/react-pinterest.git"


### PR DESCRIPTION
This fixes #4 and #7 - Will also make `npm install react-pinterest` faster and more reliable
