### PR TITLE
Utilizing PropTypes.oneOf for enums

### DIFF
--- a/src/components/PinItButton.js
+++ b/src/components/PinItButton.js
@@ -130,8 +130,8 @@ export default class PinItButton extends PinterestBase {
 }
 
 PinItButton.propTypes = {
-  type: React.PropTypes.string,
-  color: React.PropTypes.string,
+  type: React.PropTypes.oneOf(['any', 'one']),
+  color: React.PropTypes.oneOf(['red', 'white', 'gray']),
   large: React.PropTypes.bool,
   round: React.PropTypes.bool,
   pin: React.PropTypes.string,

--- a/src/components/PinterestPinWidget.js
+++ b/src/components/PinterestPinWidget.js
@@ -326,11 +326,7 @@ export default class PinterestPinWidget extends PinterestBase {
 PinterestPinWidget.propTypes = {
     pin: React.PropTypes.string.isRequired,
     lang: React.PropTypes.string,
-    size: function(props, propName, component) {
-        if (!/small|medium|large/.test(props[propName])) {
-            return new Error('PinterestPinWidget <size> must be small, medium, or large');
-        }
-    }
+    size: React.PropTypes.oneOf(['small', 'medium', 'large'])
 };
 
 PinterestPinWidget.defaultProps = {


### PR DESCRIPTION
This PR changes all props that are enums to use PropTypes.oneOf rather than the base type.
