### PR TITLE
Wrap getResolution with try/catch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pinterest",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Collection of embeddable Pinterest buttons and widgets",
   "main": "lib/main.js",
   "jsnext:main": "src/main.js",

--- a/src/util/PinUtil.js
+++ b/src/util/PinUtil.js
@@ -68,9 +68,9 @@ export default {
      * @returns {number} the screen resolution
      */
     getResolution: function() {
-        if (window) {
+        try {
             return window.devicePixelRatio >= 2 ? 2 : 1;
-        } else {
+        } catch (e) {
             return 1;
         }
     },


### PR DESCRIPTION
Server rendering is still failing with window dependency. Add wrapper around window access during render phase.
