### PR TITLE
Guard window/document references with is-browser checks

### DIFF
--- a/src/components/PinItButton.js
+++ b/src/components/PinItButton.js
@@ -1,3 +1,5 @@
+const isBrowser = typeof window !== 'undefined';
+
 import React from 'react';
 
 import PinterestBase from './PinterestBase';
@@ -69,6 +71,7 @@ export default class PinItButton extends PinterestBase {
      * @param {event} evt - the corresponding click event
      */
     pinAny(evt) {
+        if(!isBrowser) return;
         evt.preventDefault();
         var url = Const.URL.PINMARKLET + '?r=' + Math.random() * 99999999;
         Util.loadScript(url, { pinMethod: 'button' });
@@ -80,15 +83,21 @@ export default class PinItButton extends PinterestBase {
      * @returns {JSX}
      */
     renderPinOne() {
-        const {pin, media, url, description} = this.props;
+        const {pin, media} = this.props;
+        let {url, description} = this.props;
         let href;
         if (pin) {
             href = Const.URL.REPIN.replace('<id>', pin) + `?guid=${Config.guid}`;
         } else {
+            if(isBrowser) {
+              url = url || window.document.URL;
+              description = description || window.document.title;
+            }
+
             href = Const.URL.PIN_CREATE + `?guid=${Config.guid}`;
             href += `&media=${encodeURIComponent(media)}`;
-            href += `&url=${encodeURIComponent(url || document.URL)}`;
-            href += `&description=${encodeURIComponent(description || document.title)}`;
+            href += `&url=${encodeURIComponent(url)}`;
+            href += `&description=${encodeURIComponent(description)}`;
         }
         return (
             <Anchor className={this.getClasses()} href={href} log="button_pinit" popup="pin_create" >

--- a/src/util/PinUtil.js
+++ b/src/util/PinUtil.js
@@ -1,3 +1,4 @@
+const isBrowser = typeof window !== 'undefined';
 import Config from './PinConfig';
 import Const from './PinConst';
 
@@ -10,7 +11,11 @@ export default {
      * @param {object} data - key/value pairs of query parameters to log
      */
     log: function(data) {
-        let query = `?guid=${Config.guid}&via=${encodeURIComponent(location.href)}`;
+        let uri;
+        if(isBrowser) {
+          uri = window.location.href;
+        }
+        let query = `?guid=${Config.guid}&via=${encodeURIComponent(uri)}`;
         Object.keys(data).forEach(key => query += `&${key}=${encodeURIComponent(data[key])}`);
         this.loadScript(Const.URL.LOG + query, {});
     },
@@ -21,6 +26,7 @@ export default {
      * @param {object} attributes - attributes to add to the <script>
      */
     loadScript: function(src, attributes={}) {
+        if(!isBrowser) return;
         var script = document.createElement('script');
         script.src = src;
         Object.keys(attributes).forEach(key => {


### PR DESCRIPTION
To: @zackargyle 

Added:
- Add `isBrowser` const to files referencing window/document
- Guard methods where server side rendering doesn't make sense

Tested:
- Current client side rendering continues to work

Coming in future PRs:
- Testing framework or example which will demonstrate isomorphic rendering
