### PR TITLE
Bump react, babel, webpack to latest published versions

### DIFF
--- a/examples/js/main.js
+++ b/examples/js/main.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import '../../src/css/pinterest.css';
 import { 
     PinItButton,
@@ -62,4 +63,4 @@ class Examples extends React.Component {
     }
 }
 
-React.render(<Examples />, document.getElementById('app'));
+ReactDOM.render(<Examples />, document.getElementById('app'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pinterest",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Collection of embeddable Pinterest buttons and widgets",
   "main": "lib/main.js",
   "jsnext:main": "src/main.js",

--- a/package.json
+++ b/package.json
@@ -8,22 +8,22 @@
     "example": "examples"
   },
   "devDependencies": {
-    "babel-cli": "^6.2.0",
-    "babel-core": "^6.2.1",
+    "babel-cli": "^6.3.13",
+    "babel-core": "^6.3.13",
     "babel-loader": "^6.2.0",
-    "babel-preset-es2015": "^6.1.2",
-    "babel-preset-react": "^6.1.2",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
     "css-loader": "~0.9.0",
     "express": "^4.13.3",
-    "react": "^0.13.3",
+    "react": "^0.14.3",
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.4.4",
     "style-loader": "~0.8.0",
-    "webpack": "^1.10.5",
-    "webpack-dev-server": "^1.12.1"
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
   },
   "peerDependencies": {
-    "react": "^0.13.3"
+    "react": "^0.14.3"
   },
   "scripts": {
     "clean": "rimraf dist lib",

--- a/src/components/PinterestGrid.js
+++ b/src/components/PinterestGrid.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import PinterestBase from './PinterestBase';
 import Util from '../util/PinUtil';
@@ -68,9 +69,9 @@ export default class PinterestGrid extends PinterestBase {
         if (this.props.columns) {
             return this.props.columns;
         } else {
-            const rootNode = React.findDOMNode(this.refs.root);
+            const rootNode = ReactDOM.findDOMNode(this.refs.root);
             const rootWidth = rootNode.offsetWidth || rootNode.parentNode.offsetWidth;
-            const childNode = React.findDOMNode(this.refs['child-0']);
+            const childNode = ReactDOM.findDOMNode(this.refs['child-0']);
             const childWidth = childNode.offsetWidth;
             return Math.floor(rootWidth / (childWidth + this.props.gutter));
         }
@@ -85,10 +86,10 @@ export default class PinterestGrid extends PinterestBase {
         this.waitForChildren().then(() => {
             const columnCount = this.getColumnCount();
             const gutter = this.props.gutter;
-            const nodeWidth = React.findDOMNode(this.refs['child-0']).offsetWidth;
+            const nodeWidth = ReactDOM.findDOMNode(this.refs['child-0']).offsetWidth;
             let columnHeights = Array.apply(null, Array(columnCount)).map(x => 0);
             const styles = this.props.children.map((child, i) => {
-                const node = React.findDOMNode(this.refs[`child-${i}`]);
+                const node = ReactDOM.findDOMNode(this.refs[`child-${i}`]);
                 const columnIndex = this.getShortestColumn(columnHeights);
                 const top = columnHeights[columnIndex];
                 const left = columnIndex * (nodeWidth + gutter);
@@ -111,8 +112,8 @@ export default class PinterestGrid extends PinterestBase {
         return new Promise(resolve => {
             var interval = setInterval(() => {
                 const ready = this.props.children.every((child, i) => {
-                    const node = React.findDOMNode(this.refs[`child-${i}`]);
-                    return React.findDOMNode(this.refs[`child-${i}`]);
+                    const node = ReactDOM.findDOMNode(this.refs[`child-${i}`]);
+                    return ReactDOM.findDOMNode(this.refs[`child-${i}`]);
                 });
                 if (ready) {
                     clearInterval(interval);

--- a/src/components/PinterestGridWidgetBase.js
+++ b/src/components/PinterestGridWidgetBase.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactDOMServer from 'react-dom/server';
 
 import PinterestBase from './PinterestBase';
 import PinterestGrid from './PinterestGrid';
@@ -137,7 +139,7 @@ export default class PinterestGridWidgetBase extends PinterestBase {
      * @returns {JSX} the footer JSX
      */
     renderFooter() {
-        const logo = React.renderToString(<span className="grid-widget-logo"></span>);
+        const logo = ReactDOMServer.renderToString(<span className="grid-widget-logo"></span>);
         const log = `embed_${this.data.type}_ft`;
         const text = i18n.translate("Follow On $1", logo);
         const width = { width: this.getGridWidth() - border };

--- a/src/components/PinterestGridWidgetBase.js
+++ b/src/components/PinterestGridWidgetBase.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 
 import PinterestBase from './PinterestBase';


### PR DESCRIPTION
To: @zackargyle 

Updated:
- React to 0.14.3 -- and while I'm at it: Babel to 6.3.13, Webpack to 1.12.9
- Fix up deprecation warnings
- Bump version to v1.1.0 pending release
