### PR TITLE
Allow react ^15 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "express": "^4.13.3",
     "jest-cli": "^0.8.2",
     "jest-webpack-alias": "^2.0.0",
-    "react": "^0.14.3",
-    "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.6",
+    "react": "^15.2.1",
+    "react-addons-test-utils": "^15.2.1",
+    "react-dom": "^15.2.1",
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.4.4",
     "style-loader": "~0.8.0",
@@ -28,7 +28,7 @@
     "webpack-dev-server": "^1.14.0"
   },
   "peerDependencies": {
-    "react": "^0.14.3"
+    "react": "^0.14.3 || ^15.0.0"
   },
   "scripts": {
     "clean": "rimraf dist lib",


### PR DESCRIPTION
The npm package will currently generate a warning when installing in a project that is using React 15.

This does two things:
- allow React 0.14 _or_ 15 as a peerDependency
- update the React versions used for development to React 15

Tests are passing and I am able to use the components alongside React 15 without any issues.
