### PR TITLE
Updating jest to fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-preset-react": "^6.3.13",
     "css-loader": "~0.9.0",
     "express": "^4.13.3",
-    "jest-cli": "^0.8.2",
+    "jest-cli": "^14.1.0",
     "jest-webpack-alias": "^2.0.0",
     "react": "^15.2.1",
     "react-addons-test-utils": "^15.2.1",
@@ -41,6 +41,9 @@
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/jest.preprocessor.js",
+    "testPathDirs": [
+      "<rootDir>/src"
+    ],
     "testFileExtensions": [
       "es6",
       "js"

--- a/src/util/__tests__/i18n.test.js
+++ b/src/util/__tests__/i18n.test.js
@@ -28,7 +28,7 @@ describe('i18n', function() {
 
         it('should ignore setting the language to an invalid language code, returning false', () => {
             i18n.lang = 'piglatin';
-            expect(i18n.lang).toNotEqual('piglatin');
+            expect(i18n.lang).not.toEqual('piglatin');
         });
 
     });


### PR DESCRIPTION
With the update to use React 15, the test system broken. This updates to use the latest version of jest, and fall in line with it's changes. All tests are passing.
