### PR TITLE
Fix display of PinIt Button on Retina devices

### DIFF
--- a/src/components/PinItButton.js
+++ b/src/components/PinItButton.js
@@ -43,7 +43,7 @@ export default class PinItButton extends PinterestBase {
         const _color = round ? 'red' : color;
         const resolution = getResolution();
         return {
-            src: `//s-passets.pinimg.com/images/pidgets/pinit_bg_en_${shape}_${_color}_${size}_${resolution}.png`,
+            url: `//s-passets.pinimg.com/images/pidgets/pinit_bg_en_${shape}_${_color}_${size}_${resolution}.png`,
             size
         };
     }

--- a/src/components/PinItButton.js
+++ b/src/components/PinItButton.js
@@ -34,7 +34,7 @@ export default class PinItButton extends PinterestBase {
 
     /**
      * Build the url for the button image based on the color, size, and shape
-     * @returns {string} the url for the button's image
+     * @returns {object} the url for the button's image and its size
      */
     getButtonImage() {
         const { color, large, round } = this.props;
@@ -42,7 +42,10 @@ export default class PinItButton extends PinterestBase {
         const size = round ? (large ? '32' : '16') : (large ? '28' : '20');
         const _color = round ? 'red' : color;
         const resolution = getResolution();
-        return `//s-passets.pinimg.com/images/pidgets/pinit_bg_en_${shape}_${_color}_${size}_${resolution}.png`;
+        return {
+            src: `//s-passets.pinimg.com/images/pidgets/pinit_bg_en_${shape}_${_color}_${size}_${resolution}.png`,
+            size
+        };
     }
 
     /**
@@ -62,7 +65,11 @@ export default class PinItButton extends PinterestBase {
      * @returns {object} the inline style object for the button
      */
     getButtonStyle() {
-        return { backgroundImage: `url(${this.getButtonImage()})` };
+        const { url, size } = this.getButtonImage();
+        return {
+            backgroundImage: `url(${url})`,
+            backgroundSize: `${size}px ${size}px`
+        };
     }
 
     /**

--- a/src/components/PinItButton.js
+++ b/src/components/PinItButton.js
@@ -43,7 +43,7 @@ export default class PinItButton extends PinterestBase {
         const _color = round ? 'red' : color;
         const resolution = getResolution();
         return {
-            url: `//s-passets.pinimg.com/images/pidgets/pinit_bg_en_${shape}_${_color}_${size}_${resolution}.png`,
+            url: `https://s-passets.pinimg.com/images/pidgets/pinit_bg_en_${shape}_${_color}_${size}_${resolution}.png`,
             size
         };
     }


### PR DESCRIPTION
Currently, the `<PinItButton />` will be displayed incorrectly on Retina devices as the component will check for `window.devicePixelRatio`, but not scale down the background image accordingly:

![image](https://cloud.githubusercontent.com/assets/1662740/17813548/0f9f0068-662c-11e6-8f7f-cae70006cda6.png)

In order to fix this, this PR returns the target dimensions and applies them as `background-size`:

![image](https://cloud.githubusercontent.com/assets/1662740/17813575/2d8b497e-662c-11e6-9ce2-f713e111fe34.png)
