### PR TITLE
Update PinterestPinWidget.js to handle HTTPS

### DIFF
--- a/src/components/PinterestPinWidget.js
+++ b/src/components/PinterestPinWidget.js
@@ -74,9 +74,7 @@ export default class PinterestPinWidget extends PinterestBase {
      */
     getPinImage() {
         let url = this.state.pin.images['237x'].url;
-        if (window.location.protocol === 'https:') {
-            url.replace('http:', 'https:');
-        }
+        url.replace(/https?:/,'');
         switch(this.props.size) {
             case 'large':
                 return url.replace('237x', '600x');

--- a/src/components/PinterestPinWidget.js
+++ b/src/components/PinterestPinWidget.js
@@ -74,6 +74,9 @@ export default class PinterestPinWidget extends PinterestBase {
      */
     getPinImage() {
         let url = this.state.pin.images['237x'].url;
+        if (window.location.protocol === 'https:') {
+            url.replace('http:', 'https:');
+        }
         switch(this.props.size) {
             case 'large':
                 return url.replace('237x', '600x');


### PR DESCRIPTION
Since the URLs returned are hard-coded to HTTP, on a forced-HTTPS site this throws a Mixed Content warning for every image rendered into the widget (in our case, that's 200 warning!). This change auto-detects the current protocol, then replaces the URL's protocol to HTTPS if need be.